### PR TITLE
Do not require parameters with defaults

### DIFF
--- a/cmd/fpt/ChangeLog.md
+++ b/cmd/fpt/ChangeLog.md
@@ -1,3 +1,7 @@
+v1.0.5 / 2020-02-10
+-------------------
+* Do not require parameters with defaults when running `fpt run` or `fpt retrieve_data`.
+
 v1.0.4 / 2019-08-07
 -------------------
 * Fix script command with CRLF line endings.

--- a/cmd/fpt/run.go
+++ b/cmd/fpt/run.go
@@ -4,15 +4,16 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/pkg/errors"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/rightscale/policy_sdk/client/policy"
-	"github.com/rightscale/policy_sdk/sdk/applied_policy"
+	appliedpolicy "github.com/rightscale/policy_sdk/sdk/applied_policy"
 	"github.com/rightscale/policy_sdk/sdk/incident"
-	"github.com/rightscale/policy_sdk/sdk/policy_template"
+	policytemplate "github.com/rightscale/policy_sdk/sdk/policy_template"
 )
 
 // Steps:
@@ -206,8 +207,8 @@ func parseOptions(pt *policytemplate.PolicyTemplate, runOptions []string) ([]*ap
 		})
 		seen[bits[0]] = true
 	}
-	for name, _ := range pt.Parameters {
-		if !seen[name] {
+	for name, parameter := range pt.Parameters {
+		if parameter.Default == nil && !seen[name] {
 			errors = append(errors, fmt.Sprintf("%s is required", name))
 		}
 	}


### PR DESCRIPTION
- Parameters with default values should not be required when running
  `fpt run` or `fpt retrieve_data`.