### PR TITLE
Increasing the overall http timeout

### DIFF
--- a/client/policy/client.go
+++ b/client/policy/client.go
@@ -85,7 +85,7 @@ type (
 // NewClient returns a new client for RightScale Policy service.
 //   host should be the API host, such as governance-3.rightscale.com
 func NewClient(host string, projectID uint, ts auth.TokenSource, debug bool) Client {
-	var doer goahttp.Doer = &http.Client{Timeout: time.Duration(60) * time.Second}
+	var doer goahttp.Doer = &http.Client{Timeout: time.Duration(300) * time.Second}
 	// if debug {
 	// 	doer = clientwrappers.LogResponseWrap(doer)
 	// }


### PR DESCRIPTION
The http client is set to timeout in 60 sec. Our policies now traverse all subscriptions on a single tenant, taking longer to generate the data required for each datasource. I've set the client to time out after 5 minutes. 