### PR TITLE
Clean up JSON file and console.log/dir output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea/
+.vscode/
 vendor/
 version.go
 version.yml

--- a/cmd/fpt/ChangeLog.md
+++ b/cmd/fpt/ChangeLog.md
@@ -1,4 +1,4 @@
-v1.1.1 / 2020-05-18
+v1.1.1 / 2020-05-20
 -------------------
 * Clean up JSON output and output files so they are more readable without escaped `<`, `>`, and `&` characters
 * Clean up `console.log` and `console.dir` output so brackets and braces line up correctly

--- a/cmd/fpt/ChangeLog.md
+++ b/cmd/fpt/ChangeLog.md
@@ -1,3 +1,9 @@
+v1.1.1 / 2020-05-18
+-------------------
+* Clean up JSON output and output files so they are more readable without escaped `<`, `>`, and `&` characters
+* Clean up `console.log` and `console.dir` output so brackets and braces line up correctly
+* Fix a bug where the format for `fmt.Printf` included user input unnecessarily in JavaScript `console.log`/`console.dir` functions
+
 v1.1.0 / 2020-05-05
 -------------------
 * Print all JavaScript compilation errors in the `fpt script` command (#21)

--- a/cmd/fpt/ChangeLog.md
+++ b/cmd/fpt/ChangeLog.md
@@ -3,6 +3,7 @@ v1.1.1 / 2020-05-18
 * Clean up JSON output and output files so they are more readable without escaped `<`, `>`, and `&` characters
 * Clean up `console.log` and `console.dir` output so brackets and braces line up correctly
 * Fix a bug where the format for `fmt.Printf` included user input unnecessarily in JavaScript `console.log`/`console.dir` functions
+* Only write `fpt script` JSON output if there is no error
 
 v1.1.0 / 2020-05-05
 -------------------

--- a/cmd/fpt/run.go
+++ b/cmd/fpt/run.go
@@ -284,8 +284,12 @@ func cleanupRun(ctx context.Context, cli policy.Client, ap *appliedpolicy.Applie
 }
 
 func dump(v interface{}) string {
-	b, _ := json.MarshalIndent(v, "", "  ")
-	return string(b)
+	b := &strings.Builder{}
+	e := json.NewEncoder(b)
+	e.SetEscapeHTML(false)
+	e.SetIndent("", "  ")
+	e.Encode(v)
+	return b.String()
 }
 
 func appliedPolicyUILink(ap *appliedpolicy.AppliedPolicy) string {

--- a/cmd/fpt/script.go
+++ b/cmd/fpt/script.go
@@ -68,11 +68,6 @@ func runScript(ctx context.Context, file, outfile, result, name string, options 
 	}
 	src := normalizeLineEndings(string(srcBytes))
 
-	wr, err := os.Create(outfile)
-	if err != nil {
-		return err
-	}
-
 	params, err := parseParams(options)
 	if err != nil {
 		return err
@@ -126,10 +121,15 @@ func runScript(ctx context.Context, file, outfile, result, name string, options 
 	}
 
 	data, err = execScript(code, params, result)
-
 	if err != nil {
 		return err
 	}
+
+	wr, err := os.Create(outfile)
+	if err != nil {
+		return err
+	}
+	defer wr.Close()
 
 	enc := json.NewEncoder(wr)
 	enc.SetEscapeHTML(false)


### PR DESCRIPTION
* Clean up JSON output and output files so they are more readable without escaped `<`, `>`, and `&` characters
* Clean up `console.log` and `console.dir` output so brackets and braces line up correctly
* Fix a bug where the format for `fmt.Printf` included user input unnecessarily in JavaScript `console.log`/`console.dir` functions
* Only write `fpt script` JSON output if there is no error