### PR TITLE
Fix incorrect fmt.Printf and HEREDOCS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 * text=auto eol=lf
+*.pt linguist-language=Ruby

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea/
 .vscode/
+out.json
 vendor/
 version.go
 version.yml

--- a/cmd/fpt/ChangeLog.md
+++ b/cmd/fpt/ChangeLog.md
@@ -1,7 +1,7 @@
 v1.1.3 / 2020-06-26
 -------------------
 * Fix an incorrect use of `fmt.Printf` without a format to use `fmt.Print` instead
-* Handle the `'EOS'` and `"EOS"` forms of [HEREDOC](https://ruby-doc.org/core-2.2.7/doc/syntax/literals_rdoc.html#label-Here+Documents)s as a prefix when detecting JavaScript `code` blocks in the `fpt script` subcommand
+* Handle the `'EOS'` and `"EOS"` forms of [HEREDOC](https://ruby-doc.org/core-2.2.7/doc/syntax/literals_rdoc.html#label-Here+Documents)s when detecting JavaScript `code` blocks in the `fpt script` subcommand
 * Actually check if `--result`/`-r` is being passed when executing raw JavaScript with the `fpt script` subcommand
 * Handle Policy Template (Ruby) comments correctly when parsing for the `fpt script` subcommand
 

--- a/cmd/fpt/ChangeLog.md
+++ b/cmd/fpt/ChangeLog.md
@@ -1,3 +1,7 @@
+v1.1.3 / 2020-06-25
+-------------------
+* Fix an incorrect use of `fmt.Printf` without a format to use `fmt.Print` instead
+
 v1.1.2 / 2020-05-21
 -------------------
 * Actually check for any updates if `update.check` is set to `true`

--- a/cmd/fpt/ChangeLog.md
+++ b/cmd/fpt/ChangeLog.md
@@ -1,6 +1,9 @@
-v1.1.3 / 2020-06-25
+v1.1.3 / 2020-06-26
 -------------------
 * Fix an incorrect use of `fmt.Printf` without a format to use `fmt.Print` instead
+* Handle the `'EOS'` and `"EOS"` forms of [HEREDOC](https://ruby-doc.org/core-2.2.7/doc/syntax/literals_rdoc.html#label-Here+Documents)s as a prefix when detecting JavaScript `code` blocks in the `fpt script` subcommand
+* Actually check if `--result`/`-r` is being passed when executing raw JavaScript with the `fpt script` subcommand
+* Handle Policy Template (Ruby) comments correctly when parsing for the `fpt script` subcommand
 
 v1.1.2 / 2020-05-21
 -------------------

--- a/cmd/fpt/fixtures/get_script1.pt
+++ b/cmd/fpt/fixtures/get_script1.pt
@@ -58,6 +58,24 @@ RESVAR=otra[0]
 EOF
 end
 
+script 'single_quote_heredoc', type: 'javascript' do # there can be a comment here,
+  result 'output'                                    # here,
+  parameters 'a', 'b'                                # here,
+  code <<-'eos'                                      # here,
+  var output = 'Single quote HEREDOCs\nare awesome!';
+
+  console.log(a, b, output);
+  eos
+end                                                  # and here
+
+script 'double_quote_heredoc', type: 'javascript' do
+  result 'output'
+  code <<"eos"
+var output = 'Double quote HEREDOCs\\nare not that remarkable.';
+
+console.log(output);
+eos
+end
 
 policy "filter_check" do
   validate $filtered_dcs do

--- a/cmd/fpt/run.go
+++ b/cmd/fpt/run.go
@@ -106,7 +106,7 @@ func policyTemplateRun(ctx context.Context, cli policy.Client, file string, runO
 		lastEtag = *log.Etag
 		lastLog = *log.ResponseBody
 		if !noLog {
-			fmt.Printf(lastLog[lastSize:])
+			fmt.Print(lastLog[lastSize:])
 		}
 
 		//fmt.Printf("STATUS: %s\n", dump(status))

--- a/cmd/fpt/script_test.go
+++ b/cmd/fpt/script_test.go
@@ -55,6 +55,20 @@ func TestGetScripts(t *testing.T) {
 					params: []string{"otra"},
 					result: "RESVAR",
 				},
+				{
+					name:   "single_quote_heredoc",
+					code:   "  var output = 'Single quote HEREDOCs\\nare awesome!';\n\n  console.log(a, b, output);",
+					line:   65,
+					params: []string{"a", "b"},
+					result: "output",
+				},
+				{
+					name:   "double_quote_heredoc",
+					code:   "var output = 'Double quote HEREDOCs\\nare not that remarkable.';\n\nconsole.log(output);",
+					line:   74,
+					params: []string{},
+					result: "output",
+				},
 			},
 		},
 	}


### PR DESCRIPTION
* Fix an incorrect use of `fmt.Printf` without a format to use `fmt.Print` instead
* Handle the `'EOS'` and `"EOS"` forms of [HEREDOC](https://ruby-doc.org/core-2.2.7/doc/syntax/literals_rdoc.html#label-Here+Documents)s when detecting JavaScript `code` blocks in the `fpt script` subcommand
* Actually check if `--result`/`-r` is being passed when executing raw JavaScript with the `fpt script` subcommand
* Handle Policy Template (Ruby) comments correctly when parsing for the `fpt script` subcommand