### PR TITLE
Fix fpt script parameter parsing

### DIFF
--- a/cmd/fpt/ChangeLog.md
+++ b/cmd/fpt/ChangeLog.md
@@ -1,3 +1,8 @@
+v1.2.2 / 2021-01-13
+-------------------
+* Fix a bug in `fpt script` parameter parsing where non-numeric bare parameters came through as `nil` and numeric
+  parameters were not actually parsed and just came through as strings
+
 v1.2.1 / 2020-12-10
 -------------------
 * Error if a `script` block does not specify a result in `fpt script`

--- a/cmd/fpt/ChangeLog.md
+++ b/cmd/fpt/ChangeLog.md
@@ -1,4 +1,4 @@
-v1.2.2 / 2021-01-13
+v1.2.2 / 2021-01-14
 -------------------
 * Fix a bug in `fpt script` parameter parsing where non-numeric bare parameters came through as `nil` and numeric
   parameters were not actually parsed and just came through as strings

--- a/cmd/fpt/ChangeLog.md
+++ b/cmd/fpt/ChangeLog.md
@@ -1,4 +1,4 @@
-v1.2.2 / 2021-01-14
+v1.2.2 / 2021-01-15
 -------------------
 * Fix a bug in `fpt script` parameter parsing where non-numeric bare parameters came through as `nil` and numeric
   parameters were not actually parsed and just came through as strings

--- a/cmd/fpt/script.go
+++ b/cmd/fpt/script.go
@@ -277,7 +277,7 @@ func parseVal(name, v string) (interface{}, error) {
 			return nil, errors.Wrapf(err, "parameter %s: failed to parse %q as json", name, v)
 		}
 		return valJson, nil
-	} else if valN, err := coerceOption("", v, "number"); err != nil {
+	} else if valN, err := coerceOption(name, v, "number"); err == nil {
 		return valN, nil
 	}
 	return v, nil


### PR DESCRIPTION
* Fix a bug in `fpt script` parameter parsing where non-numeric bare parameters came through as `nil` and numeric parameters were not actually parsed and just came through as string