### PR TITLE
Support Flexera One EU and other fixes

### DIFF
--- a/client/policy/policy_template.go
+++ b/client/policy/policy_template.go
@@ -6,7 +6,7 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
-	"github.com/rightscale/policy_sdk/sdk/policy_template"
+	policytemplate "github.com/rightscale/policy_sdk/sdk/policy_template"
 )
 
 // UploadPolicyTemplate a policy template
@@ -150,3 +150,4 @@ func (c *client) RetrieveData(ctx context.Context, templateID string, names []st
 }
 
 func strPtr(s string) *string { return &s }
+func boolPtr(b bool) *bool    { return &b }

--- a/cmd/fpt/ChangeLog.md
+++ b/cmd/fpt/ChangeLog.md
@@ -1,4 +1,4 @@
-v1.3.0 / 2021-02-25
+v1.3.0 / 2021-02-26
 -------------------
 * Add support for Flexera One EU using `eu-central-1.policy-eu.flexeraeng.com` for the host configuration item
 * Display Flexera One URLs in `fpt run` out when using Flexera One EU or the refresh token is for Flexera One

--- a/cmd/fpt/ChangeLog.md
+++ b/cmd/fpt/ChangeLog.md
@@ -1,3 +1,10 @@
+v1.3.0 / 2021-02-24
+-------------------
+* Add support for Flexera One EU using `eu-central-1.policy-eu.flexeraeng.com` for the host configuration item
+* Display Flexera One URLs in `fpt run` out when using Flexera One EU or the refresh token is for Flexera One
+  instead of RightScale
+* Fix a bug where `fpt run` would hang trying to print the log after the policy execution completed
+
 v1.2.2 / 2021-01-15
 -------------------
 * Fix a bug in `fpt script` parameter parsing where non-numeric bare parameters came through as `nil` and numeric

--- a/cmd/fpt/ChangeLog.md
+++ b/cmd/fpt/ChangeLog.md
@@ -1,4 +1,4 @@
-v1.3.0 / 2021-02-24
+v1.3.0 / 2021-02-25
 -------------------
 * Add support for Flexera One EU using `eu-central-1.policy-eu.flexeraeng.com` for the host configuration item
 * Display Flexera One URLs in `fpt run` out when using Flexera One EU or the refresh token is for Flexera One

--- a/cmd/fpt/ChangeLog.md
+++ b/cmd/fpt/ChangeLog.md
@@ -1,4 +1,4 @@
-v1.3.0 / 2021-02-26
+v1.3.0 / 2021-03-01
 -------------------
 * Add support for Flexera One EU using `eu-central-1.policy-eu.flexeraeng.com` for the host configuration item
 * Display Flexera One URLs in `fpt run` out when using Flexera One EU or the refresh token is for Flexera One

--- a/cmd/fpt/run.go
+++ b/cmd/fpt/run.go
@@ -100,11 +100,11 @@ func policyTemplateRun(ctx context.Context, cli policy.Client, file string, runO
 		if logErr != nil {
 			// technically the Goa client should not consider 304 an error
 			if strings.Contains(logErr.Error(), "invalid response code 304") {
-				continue
+				goto checkStatus
 			}
 			// the log may not be available yet so we retry 404s
 			if gse, ok := logErr.(*goa.ServiceError); ok && gse.Name == "not_found" {
-				continue
+				goto checkStatus
 			}
 			return logErr
 		}
@@ -118,6 +118,7 @@ func policyTemplateRun(ctx context.Context, cli policy.Client, file string, runO
 			}
 		}
 
+	checkStatus:
 		//fmt.Printf("STATUS: %s\n", dump(status))
 		if status.LastEvaluationFinish != nil {
 			break

--- a/sdk/action_status/client.go
+++ b/sdk/action_status/client.go
@@ -3,7 +3,7 @@
 // ActionStatus client
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package actionstatus
 

--- a/sdk/action_status/endpoints.go
+++ b/sdk/action_status/endpoints.go
@@ -3,7 +3,7 @@
 // ActionStatus endpoints
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package actionstatus
 

--- a/sdk/action_status/service.go
+++ b/sdk/action_status/service.go
@@ -3,7 +3,7 @@
 // ActionStatus service
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package actionstatus
 

--- a/sdk/action_status/views/view.go
+++ b/sdk/action_status/views/view.go
@@ -3,7 +3,7 @@
 // ActionStatus views
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package views
 

--- a/sdk/applied_policy/client.go
+++ b/sdk/applied_policy/client.go
@@ -3,7 +3,7 @@
 // AppliedPolicy client
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package appliedpolicy
 

--- a/sdk/applied_policy/endpoints.go
+++ b/sdk/applied_policy/endpoints.go
@@ -3,7 +3,7 @@
 // AppliedPolicy endpoints
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package appliedpolicy
 

--- a/sdk/applied_policy/service.go
+++ b/sdk/applied_policy/service.go
@@ -3,7 +3,7 @@
 // AppliedPolicy service
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package appliedpolicy
 

--- a/sdk/applied_policy/views/view.go
+++ b/sdk/applied_policy/views/view.go
@@ -3,7 +3,7 @@
 // AppliedPolicy views
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package views
 

--- a/sdk/approval/client.go
+++ b/sdk/approval/client.go
@@ -3,7 +3,7 @@
 // Approval client
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package approval
 

--- a/sdk/approval/endpoints.go
+++ b/sdk/approval/endpoints.go
@@ -3,7 +3,7 @@
 // Approval endpoints
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package approval
 

--- a/sdk/approval/service.go
+++ b/sdk/approval/service.go
@@ -3,7 +3,7 @@
 // Approval service
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package approval
 

--- a/sdk/approval/views/view.go
+++ b/sdk/approval/views/view.go
@@ -3,7 +3,7 @@
 // Approval views
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package views
 

--- a/sdk/archived_incident/client.go
+++ b/sdk/archived_incident/client.go
@@ -3,7 +3,7 @@
 // ArchivedIncident client
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package archivedincident
 

--- a/sdk/archived_incident/endpoints.go
+++ b/sdk/archived_incident/endpoints.go
@@ -3,7 +3,7 @@
 // ArchivedIncident endpoints
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package archivedincident
 

--- a/sdk/archived_incident/service.go
+++ b/sdk/archived_incident/service.go
@@ -3,7 +3,7 @@
 // ArchivedIncident service
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package archivedincident
 

--- a/sdk/archived_incident/views/view.go
+++ b/sdk/archived_incident/views/view.go
@@ -3,7 +3,7 @@
 // ArchivedIncident views
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package views
 

--- a/sdk/http/action_status/client/cli.go
+++ b/sdk/http/action_status/client/cli.go
@@ -3,7 +3,7 @@
 // ActionStatus HTTP client CLI support package
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package client
 

--- a/sdk/http/action_status/client/client.go
+++ b/sdk/http/action_status/client/client.go
@@ -3,7 +3,7 @@
 // ActionStatus client HTTP transport
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package client
 

--- a/sdk/http/action_status/client/encode_decode.go
+++ b/sdk/http/action_status/client/encode_decode.go
@@ -3,7 +3,7 @@
 // ActionStatus HTTP client encoders and decoders
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package client
 

--- a/sdk/http/action_status/client/paths.go
+++ b/sdk/http/action_status/client/paths.go
@@ -3,7 +3,7 @@
 // HTTP request path constructors for the ActionStatus service.
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package client
 

--- a/sdk/http/action_status/client/types.go
+++ b/sdk/http/action_status/client/types.go
@@ -3,7 +3,7 @@
 // ActionStatus HTTP client types
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package client
 

--- a/sdk/http/applied_policy/client/cli.go
+++ b/sdk/http/applied_policy/client/cli.go
@@ -3,7 +3,7 @@
 // AppliedPolicy HTTP client CLI support package
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package client
 

--- a/sdk/http/applied_policy/client/client.go
+++ b/sdk/http/applied_policy/client/client.go
@@ -3,7 +3,7 @@
 // AppliedPolicy client HTTP transport
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package client
 

--- a/sdk/http/applied_policy/client/encode_decode.go
+++ b/sdk/http/applied_policy/client/encode_decode.go
@@ -3,7 +3,7 @@
 // AppliedPolicy HTTP client encoders and decoders
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package client
 

--- a/sdk/http/applied_policy/client/paths.go
+++ b/sdk/http/applied_policy/client/paths.go
@@ -3,7 +3,7 @@
 // HTTP request path constructors for the AppliedPolicy service.
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package client
 

--- a/sdk/http/applied_policy/client/types.go
+++ b/sdk/http/applied_policy/client/types.go
@@ -3,7 +3,7 @@
 // AppliedPolicy HTTP client types
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package client
 

--- a/sdk/http/approval/client/cli.go
+++ b/sdk/http/approval/client/cli.go
@@ -3,7 +3,7 @@
 // Approval HTTP client CLI support package
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package client
 

--- a/sdk/http/approval/client/client.go
+++ b/sdk/http/approval/client/client.go
@@ -3,7 +3,7 @@
 // Approval client HTTP transport
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package client
 

--- a/sdk/http/approval/client/encode_decode.go
+++ b/sdk/http/approval/client/encode_decode.go
@@ -3,7 +3,7 @@
 // Approval HTTP client encoders and decoders
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package client
 

--- a/sdk/http/approval/client/paths.go
+++ b/sdk/http/approval/client/paths.go
@@ -3,7 +3,7 @@
 // HTTP request path constructors for the Approval service.
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package client
 

--- a/sdk/http/approval/client/types.go
+++ b/sdk/http/approval/client/types.go
@@ -3,7 +3,7 @@
 // Approval HTTP client types
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package client
 

--- a/sdk/http/archived_incident/client/cli.go
+++ b/sdk/http/archived_incident/client/cli.go
@@ -3,7 +3,7 @@
 // ArchivedIncident HTTP client CLI support package
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package client
 

--- a/sdk/http/archived_incident/client/client.go
+++ b/sdk/http/archived_incident/client/client.go
@@ -3,7 +3,7 @@
 // ArchivedIncident client HTTP transport
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package client
 

--- a/sdk/http/archived_incident/client/encode_decode.go
+++ b/sdk/http/archived_incident/client/encode_decode.go
@@ -3,7 +3,7 @@
 // ArchivedIncident HTTP client encoders and decoders
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package client
 

--- a/sdk/http/archived_incident/client/paths.go
+++ b/sdk/http/archived_incident/client/paths.go
@@ -3,7 +3,7 @@
 // HTTP request path constructors for the ArchivedIncident service.
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package client
 

--- a/sdk/http/archived_incident/client/types.go
+++ b/sdk/http/archived_incident/client/types.go
@@ -3,7 +3,7 @@
 // ArchivedIncident HTTP client types
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package client
 

--- a/sdk/http/cli/governance/cli.go
+++ b/sdk/http/cli/governance/cli.go
@@ -3,7 +3,7 @@
 // Governance HTTP client CLI support package
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package cli
 

--- a/sdk/http/incident/client/cli.go
+++ b/sdk/http/incident/client/cli.go
@@ -3,7 +3,7 @@
 // Incident HTTP client CLI support package
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package client
 

--- a/sdk/http/incident/client/client.go
+++ b/sdk/http/incident/client/client.go
@@ -3,7 +3,7 @@
 // Incident client HTTP transport
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package client
 

--- a/sdk/http/incident/client/encode_decode.go
+++ b/sdk/http/incident/client/encode_decode.go
@@ -3,7 +3,7 @@
 // Incident HTTP client encoders and decoders
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package client
 

--- a/sdk/http/incident/client/paths.go
+++ b/sdk/http/incident/client/paths.go
@@ -3,7 +3,7 @@
 // HTTP request path constructors for the Incident service.
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package client
 

--- a/sdk/http/incident/client/types.go
+++ b/sdk/http/incident/client/types.go
@@ -3,7 +3,7 @@
 // Incident HTTP client types
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package client
 

--- a/sdk/http/incident_aggregate/client/cli.go
+++ b/sdk/http/incident_aggregate/client/cli.go
@@ -3,7 +3,7 @@
 // IncidentAggregate HTTP client CLI support package
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package client
 

--- a/sdk/http/incident_aggregate/client/client.go
+++ b/sdk/http/incident_aggregate/client/client.go
@@ -3,7 +3,7 @@
 // IncidentAggregate client HTTP transport
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package client
 

--- a/sdk/http/incident_aggregate/client/encode_decode.go
+++ b/sdk/http/incident_aggregate/client/encode_decode.go
@@ -3,7 +3,7 @@
 // IncidentAggregate HTTP client encoders and decoders
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package client
 

--- a/sdk/http/incident_aggregate/client/paths.go
+++ b/sdk/http/incident_aggregate/client/paths.go
@@ -3,7 +3,7 @@
 // HTTP request path constructors for the IncidentAggregate service.
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package client
 

--- a/sdk/http/incident_aggregate/client/types.go
+++ b/sdk/http/incident_aggregate/client/types.go
@@ -3,7 +3,7 @@
 // IncidentAggregate HTTP client types
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package client
 

--- a/sdk/http/policy_aggregate/client/cli.go
+++ b/sdk/http/policy_aggregate/client/cli.go
@@ -3,7 +3,7 @@
 // PolicyAggregate HTTP client CLI support package
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package client
 

--- a/sdk/http/policy_aggregate/client/client.go
+++ b/sdk/http/policy_aggregate/client/client.go
@@ -3,7 +3,7 @@
 // PolicyAggregate client HTTP transport
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package client
 

--- a/sdk/http/policy_aggregate/client/encode_decode.go
+++ b/sdk/http/policy_aggregate/client/encode_decode.go
@@ -3,7 +3,7 @@
 // PolicyAggregate HTTP client encoders and decoders
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package client
 

--- a/sdk/http/policy_aggregate/client/paths.go
+++ b/sdk/http/policy_aggregate/client/paths.go
@@ -3,7 +3,7 @@
 // HTTP request path constructors for the PolicyAggregate service.
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package client
 

--- a/sdk/http/policy_aggregate/client/types.go
+++ b/sdk/http/policy_aggregate/client/types.go
@@ -3,7 +3,7 @@
 // PolicyAggregate HTTP client types
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package client
 

--- a/sdk/http/policy_template/client/cli.go
+++ b/sdk/http/policy_template/client/cli.go
@@ -3,7 +3,7 @@
 // PolicyTemplate HTTP client CLI support package
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package client
 

--- a/sdk/http/policy_template/client/client.go
+++ b/sdk/http/policy_template/client/client.go
@@ -3,7 +3,7 @@
 // PolicyTemplate client HTTP transport
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package client
 

--- a/sdk/http/policy_template/client/encode_decode.go
+++ b/sdk/http/policy_template/client/encode_decode.go
@@ -3,7 +3,7 @@
 // PolicyTemplate HTTP client encoders and decoders
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package client
 

--- a/sdk/http/policy_template/client/paths.go
+++ b/sdk/http/policy_template/client/paths.go
@@ -3,7 +3,7 @@
 // HTTP request path constructors for the PolicyTemplate service.
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package client
 

--- a/sdk/http/policy_template/client/types.go
+++ b/sdk/http/policy_template/client/types.go
@@ -3,7 +3,7 @@
 // PolicyTemplate HTTP client types
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package client
 

--- a/sdk/http/published_template/client/cli.go
+++ b/sdk/http/published_template/client/cli.go
@@ -3,7 +3,7 @@
 // PublishedTemplate HTTP client CLI support package
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package client
 

--- a/sdk/http/published_template/client/client.go
+++ b/sdk/http/published_template/client/client.go
@@ -3,7 +3,7 @@
 // PublishedTemplate client HTTP transport
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package client
 

--- a/sdk/http/published_template/client/encode_decode.go
+++ b/sdk/http/published_template/client/encode_decode.go
@@ -3,7 +3,7 @@
 // PublishedTemplate HTTP client encoders and decoders
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package client
 

--- a/sdk/http/published_template/client/paths.go
+++ b/sdk/http/published_template/client/paths.go
@@ -3,7 +3,7 @@
 // HTTP request path constructors for the PublishedTemplate service.
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package client
 

--- a/sdk/http/published_template/client/types.go
+++ b/sdk/http/published_template/client/types.go
@@ -3,7 +3,7 @@
 // PublishedTemplate HTTP client types
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package client
 

--- a/sdk/incident/client.go
+++ b/sdk/incident/client.go
@@ -3,7 +3,7 @@
 // Incident client
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package incident
 

--- a/sdk/incident/endpoints.go
+++ b/sdk/incident/endpoints.go
@@ -3,7 +3,7 @@
 // Incident endpoints
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package incident
 

--- a/sdk/incident/service.go
+++ b/sdk/incident/service.go
@@ -3,7 +3,7 @@
 // Incident service
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package incident
 

--- a/sdk/incident/views/view.go
+++ b/sdk/incident/views/view.go
@@ -3,7 +3,7 @@
 // Incident views
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package views
 

--- a/sdk/incident_aggregate/client.go
+++ b/sdk/incident_aggregate/client.go
@@ -3,7 +3,7 @@
 // IncidentAggregate client
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package incidentaggregate
 

--- a/sdk/incident_aggregate/endpoints.go
+++ b/sdk/incident_aggregate/endpoints.go
@@ -3,7 +3,7 @@
 // IncidentAggregate endpoints
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package incidentaggregate
 

--- a/sdk/incident_aggregate/service.go
+++ b/sdk/incident_aggregate/service.go
@@ -3,7 +3,7 @@
 // IncidentAggregate service
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package incidentaggregate
 

--- a/sdk/incident_aggregate/views/view.go
+++ b/sdk/incident_aggregate/views/view.go
@@ -3,7 +3,7 @@
 // IncidentAggregate views
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package views
 

--- a/sdk/policy_aggregate/client.go
+++ b/sdk/policy_aggregate/client.go
@@ -3,7 +3,7 @@
 // PolicyAggregate client
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package policyaggregate
 

--- a/sdk/policy_aggregate/endpoints.go
+++ b/sdk/policy_aggregate/endpoints.go
@@ -3,7 +3,7 @@
 // PolicyAggregate endpoints
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package policyaggregate
 

--- a/sdk/policy_aggregate/service.go
+++ b/sdk/policy_aggregate/service.go
@@ -3,7 +3,7 @@
 // PolicyAggregate service
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package policyaggregate
 

--- a/sdk/policy_aggregate/views/view.go
+++ b/sdk/policy_aggregate/views/view.go
@@ -3,7 +3,7 @@
 // PolicyAggregate views
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package views
 

--- a/sdk/policy_template/client.go
+++ b/sdk/policy_template/client.go
@@ -3,7 +3,7 @@
 // PolicyTemplate client
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package policytemplate
 

--- a/sdk/policy_template/endpoints.go
+++ b/sdk/policy_template/endpoints.go
@@ -3,7 +3,7 @@
 // PolicyTemplate endpoints
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package policytemplate
 

--- a/sdk/policy_template/service.go
+++ b/sdk/policy_template/service.go
@@ -3,7 +3,7 @@
 // PolicyTemplate service
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package policytemplate
 

--- a/sdk/policy_template/views/view.go
+++ b/sdk/policy_template/views/view.go
@@ -3,7 +3,7 @@
 // PolicyTemplate views
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package views
 

--- a/sdk/published_template/client.go
+++ b/sdk/published_template/client.go
@@ -3,7 +3,7 @@
 // PublishedTemplate client
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package publishedtemplate
 

--- a/sdk/published_template/endpoints.go
+++ b/sdk/published_template/endpoints.go
@@ -3,7 +3,7 @@
 // PublishedTemplate endpoints
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package publishedtemplate
 

--- a/sdk/published_template/service.go
+++ b/sdk/published_template/service.go
@@ -3,7 +3,7 @@
 // PublishedTemplate service
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package publishedtemplate
 

--- a/sdk/published_template/views/view.go
+++ b/sdk/published_template/views/view.go
@@ -3,7 +3,7 @@
 // PublishedTemplate views
 //
 // Command:
-// $ goa gen github.com/rightscale/governance/front_service/design
+// $ goa gen github.com/rightscale/governance/front_service/design -o .
 
 package views
 


### PR DESCRIPTION
* Add support for Flexera One EU using `eu-central-1.policy-eu.flexeraeng.com` for the host configuration item
* Display Flexera One URLs in `fpt run` out when using Flexera One EU or the refresh token is for Flexera One instead of RightScale
* Fix a bug where `fpt run` would hang trying to print the log after the policy execution complete