### PR TITLE
fix: include target version in asset name for download URL

### DIFF
--- a/cmd/fpt/update.go
+++ b/cmd/fpt/update.go
@@ -178,7 +178,7 @@ func UpdateGetDownloadUrl(majorVersion int) (string, *Version, error) {
 	if runtime.GOOS == "windows" {
 		ext = "zip"
 	}
-	assetName := fmt.Sprintf("%s-%s-%s.%s", app.Name, runtime.GOOS, runtime.GOARCH, ext)
+	assetName := fmt.Sprintf("%s-%s-%s-%s.%s", app.Name, runtime.GOOS, runtime.GOARCH, targetVersion.String(), ext)
 
 	// find the matching asset in the release
 	for _, asset := range targetRelease.Assets {


### PR DESCRIPTION
This pull request updates the naming convention for download assets to include the target version in the filename. This change helps ensure that asset names are unique per version, which can prevent confusion or overwriting issues when handling multiple versions.

Asset naming improvement:

* Updated the `assetName` variable in `UpdateGetDownloadUrl` to include the `targetVersion` in the generated filename, making asset identification clearer and more robust.